### PR TITLE
refact: downgrade cuda driver requirement for docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,8 @@
-.git
+.git*
 *build*
 data
 3rdparty
+docs
+.clang-format
+.readthedocs.yml
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,34 +2,34 @@
 
 # docker build .
 
-# Based on CUDA11.0 & CuDNN8
-FROM nvidia/cuda:10.2-devel-ubuntu18.04
-
-# Test connection
-RUN apt update --allow-unauthenticated && apt install -y wget && wget www.google.com
-
-# Install Non-GPU Dependencies.
-RUN version="7.0.0-1+cuda10.2" ; \
-    apt install -y \
-    libnvinfer7=${version} libnvonnxparsers7=${version} libnvparsers7=${version} \
-    libnvinfer-plugin7=${version} libnvinfer-dev=${version} libnvonnxparsers-dev=${version} \
-    libnvparsers-dev=${version} libnvinfer-plugin-dev=${version} python-libnvinfer=${version} \
-    python3-libnvinfer=${version} && \
-    apt-mark hold \
-    libnvinfer7 libnvonnxparsers7 libnvparsers7 libnvinfer-plugin7 libnvinfer-dev libnvonnxparsers-dev libnvparsers-dev libnvinfer-plugin-dev python-libnvinfer python3-libnvinfer
+# Based on CUDA10.0 & CuDNN7
+FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04
 
 # Set apt-get to automatically retry if a package download fails
 RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/99AcquireRetries
 
+# apt update
+RUN apt update --allow-unauthenticated
+
+# Install Non-GPU Dependencies.
+RUN version="7.0.0-1+cuda10.0" ; \
+    apt install -y \
+    libnvinfer7=${version} libnvonnxparsers7=${version} libnvparsers7=${version} \
+    libnvinfer-plugin7=${version} libnvinfer-dev=${version} libnvonnxparsers-dev=${version} \
+    libnvparsers-dev=${version} libnvinfer-plugin-dev=${version} && \
+    apt-mark hold \
+    libnvinfer7 libnvonnxparsers7 libnvparsers7 libnvinfer-plugin7 libnvinfer-dev libnvonnxparsers-dev libnvparsers-dev libnvinfer-plugin-dev \
+#    && apt install -yt python-libnvinfer=${version} python3-libnvinfer=${version} && apt-mark hold python-libnvinfer python3-libnvinfer
+
 # Install OpenCV Dependencies
 RUN apt install -y software-properties-common || apt install -y software-properties-common && \
     add-apt-repository "deb http://security.ubuntu.com/ubuntu xenial-security main" && \
-    APT_DEPS="git cmake libgtk-3-dev libavcodec-dev libavformat-dev libswscale-dev libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libjasper-dev libdc1394-22-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev x264 v4l-utils python3-dev python3-pip libcanberra-gtk-module libcanberra-gtk3-module" && \
+    APT_DEPS="git cmake wget zip libgtk-3-dev libavcodec-dev libavformat-dev libswscale-dev libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libjasper-dev libdc1394-22-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev x264 v4l-utils python3-dev python3-pip libcanberra-gtk-module libcanberra-gtk3-module" && \
     apt install -y $APT_DEPS || apt install -y $APT_DEPS && \
     python3 -m pip install numpy
 
 # Compile OpenCV
-RUN apt install -y zip && wget https://github.com/opencv/opencv/archive/refs/tags/4.4.0.zip && unzip 4.4.0.zip && \
+RUN wget https://github.com/opencv/opencv/archive/refs/tags/4.4.0.zip && unzip 4.4.0.zip && \
     cd opencv-4.4.0 && mkdir build && cd build && \
     cmake .. -DCMAKE_BUILD_TYPE=Release \
              -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -44,13 +44,17 @@ RUN apt install -y python3-dev python3-pip subversion libgflags-dev
 
 COPY . /hyperpose
 
-# Get models
+# Get models: we first see if there's existing models here. If not install it throught network.
 # NOTE: if you cannot install the models due to network issues:
 #   1    Manually install ONNX and UFF models through: https://drive.google.com/drive/folders/1w9EjMkrjxOmMw3Rf6fXXkiv_ge7M99jR
 #   2    Put all models into `${GIT_DIR}/pre_installed_models`
-#   3.1  `RUN /hyperpose/scripts/download-test-data.sh`
-#   3.2  `RUN mv /hyperpose/pre_installed_models /hyperpose/data/models`
-RUN for file in $(find /hyperpose/scripts -type f -iname 'download*.sh'); do sh $file; done
+#   3    Re-build this docker image.
+RUN ( [ `find /hyperpose/pre_installed_models -regex '.*\.\(onnx\|uff\)' | wc -l` > 0 ] && \
+    mkdir -p /hyperpose/data && mv /hyperpose/pre_installed_models/ /hyperpose/data/models ) || \
+    for file in $(find /hyperpose/scripts -type f -iname 'download-*-model.sh'); do sh $file; done
+
+# Install test data.
+RUN /hyperpose/scripts/download-test-data.sh
 
 # Build Repo
 RUN cd hyperpose && mkdir build && cd build && \

--- a/docs/markdown/install/prediction.md
+++ b/docs/markdown/install/prediction.md
@@ -7,6 +7,14 @@ HyperPose is developed and frequently tested on Linux platforms. Hence, we recom
 
 To ease the installation, you can use HyperPose library in our docker image where the environment is pre-installed.
 
+### Prerequisites
+
+You can simply run `python scripts/check_docker_run.py` to check your environment and get related instructions.
+
+- [CUDA Driver >= 410.48](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#driver-installation)
+- [NVidia Docker >= 2.0](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#pre-requisites)
+- [Docker >= 19.03](https://docs.docker.com/engine/install/)
+
 ### Official Docker Image
 
 NVidia docker support is required to execute our docker image. 

--- a/scripts/auto-format.sh
+++ b/scripts/auto-format.sh
@@ -2,13 +2,13 @@ set -e
 
 export CLANG_FORMAT=clang-format
 
-[ $(which $CLANG_FORMAT) ] || python3 -m pip install clang-format
+command -v $CLANG_FORMAT || python3 -m pip install clang-format
 
 format_dir() {
-    find $1 -regex '.*\.\(cpp\|hpp\|cc\|cxx\)' -exec $CLANG_FORMAT -style=file -i {} \;
+    find "$1" -regex '.*\.\(cpp\|hpp\|cc\|cxx\)' -exec $CLANG_FORMAT -style=file -i {} \;
 }
 
-cd $(dirname $0)/..
+cd "$(dirname "$0")"/..
 
 format_dir ./examples
 format_dir ./include

--- a/scripts/check_docker_run.py
+++ b/scripts/check_docker_run.py
@@ -1,0 +1,58 @@
+import os
+import unittest
+import re
+from distutils.version import StrictVersion
+
+
+class LinuxCheck(unittest.TestCase):
+    def test_cuda_driver(self):
+        p = os.popen('cat /proc/driver/nvidia/version')
+        output = p.read()
+        p.close()
+        self.assertTrue('NVIDIA' in output.upper(), 'NVIDIA Driver not found. Please visit '
+                                                    'https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index'
+                                                    '.html '
+                                                    '#driver-installation')
+        if 'NVIDIA' in output.upper():
+            version_code = None
+            for line in output.splitlines():
+                if 'NVIDIA' in line:
+                    for item in line.split(' '):
+                        m = re.search('[0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]', item)
+                        if m is not None:
+                            version_code = m.group(0)
+                            break
+            self.assertNotEqual(version_code, None, 'NVIDIA version not found...')
+            if version_code is not None:
+                self.assertGreaterEqual(StrictVersion(version_code), StrictVersion('410.48'), 'Your CUDA driver is '
+                                                                                              'old. Please upgrade it '
+                                                                                              'to >= 410.48 according '
+                                                                                              'to '
+                                                                                              'https://docs.nvidia'
+                                                                                              '.com/cuda/cuda'
+                                                                                              '-installation-guide'
+                                                                                              '-linux/index.html'
+                                                                                              '#driver-installation')
+
+    def test_docker_version(self):
+        p = os.popen("docker version --format '{{.Client.Version}}'")
+        version_code = p.read()
+        return_code = p.close()
+        self.assertEqual(return_code, None, 'docker command not found...')
+        self.assertNotEqual(version_code, None, 'Docker version cannot be found...')
+        self.assertGreaterEqual(StrictVersion(version_code), StrictVersion('19.03'), 'Your docker version is too old '
+                                                                                     'to support "--gpus" flag... '
+                                                                                     'Please install a newer version '
+                                                                                     '(>= 19.03) via '
+                                                                                     'https://docs.docker.com/engine'
+                                                                                     '/install/')
+
+    def test_nvidia_docker(self):
+        return_code = os.system("docker run --rm --gpus all nvidia/cuda:10.0-base nvidia-smi")
+        self.assertEqual(return_code, 0, 'Docker with CUDA functionality cannot run properly. Please visit '
+                                         'https://docs.nvidia.com/datacenter/cloud-native/container-toolkit'
+                                         '/install-guide.html#pre-requisites to install latest nvidia container')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
apt for Ubuntu18.04's default cuda driver version cannot meet CUDA10.2's requirement. Let's downgrade it to CUDA10 (so that users of Ubuntu18.04 do not have to install new drivers from PPA).
cc @Gyx-One 